### PR TITLE
Add tile type selection

### DIFF
--- a/creative-world-plus/data-updates.lua
+++ b/creative-world-plus/data-updates.lua
@@ -1,0 +1,36 @@
+data.raw["map-gen-presets"]["default"]["creative-world-plus"] =
+{
+	order = "w",
+	basic_settings =
+	{
+		autoplace_controls = {
+			["iron-ore"] = {
+				size = "none"
+			},
+			["copper-ore"] = {
+				size = "none"
+			},
+			["coal"] = {
+				size = "none"
+			},
+			["stone"] = {
+				size = "none",
+			},
+			["crude-oil"] = {
+				size = "none"
+			},
+			["uranium-ore"] = {
+				size = "none"
+            },
+            ["trees"] = {
+                size = "none"
+            }
+		},
+        water = "none",
+        cliff_settings = {
+            name = "none",
+            cliff_elevation_interval = 40,
+            cliff_elevation_0 = 1024
+        }
+	}
+}

--- a/creative-world-plus/data.lua
+++ b/creative-world-plus/data.lua
@@ -1,4 +1,5 @@
 local tiles_to_pave = settings.startup["creative-world-plus_tiles-to-pave"].value
+local tile_type = settings.startup["creative-world-plus_tile-type"].value
 if (tiles_to_pave == "All" or tiles_to_pave == "Land Tiles Only") then
     for _, tile in pairs (data.raw.tile) do
         if (tiles_to_pave == "All") then
@@ -9,7 +10,7 @@ if (tiles_to_pave == "All" or tiles_to_pave == "Land Tiles Only") then
             end
         end
     end
-    data.raw.tile["refined-concrete"].autoplace = {}
+    data.raw.tile[tile_type].autoplace = {}
 end
 if (settings.startup["creative-world-plus_remove-rocks"].value == true) then
     --[[Simple entities with autoplace are the rocks]]

--- a/creative-world-plus/locale/en/locale.cfg
+++ b/creative-world-plus/locale/en/locale.cfg
@@ -10,10 +10,12 @@ creative-world-plus_remove-rocks=Remove Rocks
 creative-world-plus_remove-trees=Remove Trees
 creative-world-plus_remove-decorative=Remove Decorations
 creative-world-plus_remove-fish=Remove Fish
+creative-world-plus_tile-type=Type of tile to pave with
 
 [mod-setting-description]
-creative-world-plus_tiles-to-pave=The type of tiles you want to converted to refined concrete
+creative-world-plus_tiles-to-pave=The type of tiles you want paved over
 creative-world-plus_remove-rocks=Prevents rocks from being generated
 creative-world-plus_remove-trees=Prevents trees from being generated
 creative-world-plus_remove-decorative=Prevents doodads that clutter the ground
 creative-world-plus_remove-fish=Prevents fish from being generated
+creative-world-plus_tile-type=The type of tile ou want to cover the world with (default is concrete)

--- a/creative-world-plus/locale/en/locale.cfg
+++ b/creative-world-plus/locale/en/locale.cfg
@@ -1,3 +1,9 @@
+[map-gen-preset-name]
+creative-world-plus=Creative World Plus (empty world)
+
+[map-gen-preset-description]
+creative-world-plus=Empty world with no water, trees, ores or oil. Usefull for creative mode.
+
 [mod-setting-name]
 creative-world-plus_tiles-to-pave=Type of tiles to pave
 creative-world-plus_remove-rocks=Remove Rocks

--- a/creative-world-plus/settings.lua
+++ b/creative-world-plus/settings.lua
@@ -1,3 +1,10 @@
+
+-- all tiles (as of 0.16)
+local tiles = {"concrete", "deepwater", "deepwater-green", "dirt-1", "dirt-2", "dirt-3", "dirt-4", "dirt-5", "dirt-6", "dirt-7", "dry-dirt", "grass-1", "grass-2", "grass-3", "grass-4", "hazard-concrete-left", "hazard-concrete-right", "lab-dark-1", "lab-dark-2", "lab-white", "out-of-map", "red-desert-0", "red-desert-1", "red-desert-2", "red-desert-3", "refined-concrete", "refined-hazard-concrete-left", "refined-hazard-concrete-right", "sand-1", "sand-2", "sand-3", "stone-path", "tutorial-grid", "water", "water-green"}
+
+-- mostly usefull tiles
+-- local tiles = {"concrete", "refined-concrete", "lab-dark-1", "lab-dark-2", "lab-white", "stone-path", "tutorial-grid"}
+
 data:extend({
     {
         type = "string-setting",
@@ -27,5 +34,13 @@ data:extend({
         setting_type = "startup",
         default_value = true,
         order="d"
+    },
+    {
+        type = "string-setting",
+        name = "creative-world-plus_tile-type",
+        setting_type = "startup",
+        default_value = "concrete",
+        allowed_values = tiles,
+        order="e"
     }
 })


### PR DESCRIPTION
This adds two things:
1. Map generator preset which creates world without water, resources cliffs and trees.
2. Mod setting to choose tile type (since settings.lua is loaded before prototypes are built, I had to hard code all tile names, see settings.lua#2-6)